### PR TITLE
Fix expires_in example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ payload = {
   user_id: 123_456,
   action: :authenticate
 }
-encrypted_data = RubyMagicLink::Token.create(payload, expires_in: Time.now.to_i + 3600)
+encrypted_data = RubyMagicLink::Token.create(payload, expires_in: 3600)
 url = "https://example.com/magic_links?data=#{encrypted_data}"
 
 # Send the generated URL in an email or through other communication channels.


### PR DESCRIPTION
The current time is now handled [internally](https://github.com/igorkorepanov/ruby_magic_link/commit/3f542289d23ca8f04099c33f338e329043e8132b#diff-0bb9cdcd98ff9296977edeb956319816fb6106eb7dac6c7e57c188a10ccb7180), removing the need for `Time.now` calls.  